### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <h3 align="left">Connect with me:</h3>
 <p align="left">
 <a href="https://twitter.com/varunsh96468766" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="varunsh96468766" height="30" width="40" /></a>
-<a href="https://linkedin.com/in/https://www.linkedin.com/in/varun-shrivastava-789701200/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="https://www.linkedin.com/in/varun-shrivastava-789701200/" height="30" width="40" /></a>
+<a href="https://www.linkedin.com/in/varun-shrivastava-789701200/" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="https://www.linkedin.com/in/varun-shrivastava-789701200/" height="30" width="40" /></a>
 <a href="https://www.hackerrank.com/varun2706" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/hackerrank.svg" alt="varun2706" height="30" width="40" /></a>
 </p>
 


### PR DESCRIPTION
:bug: The previous LinkedIn logo link leads to the following page.

<img width="60%" height="auto" src="https://user-images.githubusercontent.com/56636487/144365194-8cd1fe77-20a8-42ab-8957-fbeaf532e14d.png">

🛠️ Fixed the LinkedIn link.

✅ Loads the mentioned LinkedIn profile.

<img width="60%" height="auto" src="https://user-images.githubusercontent.com/56636487/144364757-e48f4bc9-1abd-4bc4-ad0c-67cd7b08dc3b.png">
